### PR TITLE
Make the plugin recognize buildessentials

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ complete it. When autocompleting a fully written command, the full command refer
 Unit and Functional Testing
 ---------------------------
 
-In order to save a few keystrokes when typing ``phpunit -c ..../Build/Common/PhpUnit/UnitTests.xml path/to/MyTest.php``,
+In order to save a few keystrokes when typing ``phpunit -c .../Build/.../PhpUnit/UnitTests.xml path/to/MyTest.php``,
 there are two commands available: ``f3functionaltest`` and ``f3unittest``.
 
 They, as well, can be called inside every subfolder of the FLOW3 distribution::

--- a/flow3.plugin.zsh
+++ b/flow3.plugin.zsh
@@ -121,7 +121,11 @@ f3unittest() {
   done
   local flow3BaseDir=`pwd`
   cd $startDirectory
-  phpunit -c $flow3BaseDir/Build/Common/PhpUnit/UnitTests.xml --colors $@
+  if [ -f $flow3BaseDir/Build/Common ]; then
+      phpunit -c $flow3BaseDir/Build/Common/PhpUnit/UnitTests.xml --colors $@
+  else
+      phpunit -c $flow3BaseDir/Build/buildessentials/PhpUnit/UnitTests.xml --colors $@
+  fi
 }
 
 #
@@ -140,7 +144,11 @@ f3functionaltest() {
   done
   local flow3BaseDir=`pwd`
   cd $startDirectory
-  phpunit -c $flow3BaseDir/Build/Common/PhpUnit/FunctionalTests.xml --colors $@
+  if [ -f $flow3BaseDir/Build/Common ]; then
+      phpunit -c $flow3BaseDir/Build/Common/PhpUnit/FunctionalTests.xml --colors $@
+  else
+      phpunit -c $flow3BaseDir/Build/buildessentials/PhpUnit/FunctionalTests.xml --colors $@
+  fi
 }
 
 ######################################


### PR DESCRIPTION
With composer the name of Build/Common changes to
Build/buildessentials. Adjust the plugin as needed.
