### PR TITLE
Update phpunit path for BuildEssentials directory

### DIFF
--- a/flow3.plugin.zsh
+++ b/flow3.plugin.zsh
@@ -121,7 +121,7 @@ funittest() {
   done
   local flowBaseDir=`pwd`
   cd $startDirectory
-  phpunit -c $flowBaseDir/Build/buildessentials/PhpUnit/UnitTests.xml --colors $@
+  phpunit -c $flowBaseDir/Build/BuildEssentials/PhpUnit/UnitTests.xml --colors $@
 }
 
 #
@@ -140,7 +140,7 @@ ffunctionaltest() {
   done
   local flowBaseDir=`pwd`
   cd $startDirectory
-  phpunit -c $flowBaseDir/Build/buildessentials/PhpUnit/FunctionalTests.xml --colors $@
+  phpunit -c $flowBaseDir/Build/BuildEssentials/PhpUnit/FunctionalTests.xml --colors $@
 }
 
 ##################################################################################################


### PR DESCRIPTION
In TYPO3 Flow 2.0, the naming for BuildEssentials dir is written in upper camel case and not in all small case anymore so this needs to be adjusted in the script.
